### PR TITLE
ci: use release-bot app token to publish CocoaPods

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: Woosmap
+          repositories: |
+            geofencing-ios-sdk-release
+            geofencing-enterprise-ios-sdk
+
       - name: Download artifact zip
         run: |
-          curl -L -H "Authorization: token ${{ secrets.WOOSMAP_GITHUB_TOKEN }}" \
+          curl -L -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -o $RUNNER_TEMP/artifact.zip \
             https://api.github.com/repos/Woosmap/geofencing-enterprise-ios-sdk/actions/artifacts/${{ github.event.client_payload.artifact_id }}/zip
 
-          curl -L -H "Authorization: token ${{ secrets.WOOSMAP_GITHUB_TOKEN }}" \
+          curl -L -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
               -o $RUNNER_TEMP/sdk.zip \
               https://api.github.com/repos/Woosmap/geofencing-enterprise-ios-sdk/actions/artifacts/${{ github.event.client_payload.sdk_artifact_id }}/zip
 
@@ -32,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: update latest version of SDK
         run: |
@@ -63,13 +75,15 @@ jobs:
             echo "update=${_isbranchUpdated}" >> "$GITHUB_OUTPUT"
           
       - name: Commit and push changes
-        if: ${{ steps.branchstatus.outputs.update == 'true'}}
-        uses: devops-infra/action-commit-push@master
-        with:
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            commit_message: "Updated ${{ github.event.client_payload.v }}"
-            commit_prefix: "[AUTO]"
-            force: false
+        if: ${{ steps.branchstatus.outputs.update == 'true' }}
+        run: |
+          git config user.name  "release-bot[bot]"
+          git config user.email "release-bot[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "[AUTO] Updated ${VERSION}"
+          git push origin HEAD:${{ github.event.repository.default_branch }}
+        env:
+          VERSION: ${{ github.event.client_payload.v }}
       
       - name: Create Git tag
         run: |


### PR DESCRIPTION
## Issue
#2

## Describe your changes
Switches the CocoaPods publish workflow to authenticate via a GitHub App (`release-bot`) token instead of the personal `WOOSMAP_GITHUB_TOKEN`:

- Adds an `actions/create-github-app-token@v1` step scoped to `geofencing-ios-sdk-release` and `geofencing-enterprise-ios-sdk`.
- Uses the app token for downloading artifacts from the enterprise repo and for the `checkout` step.
- Replaces the `devops-infra/action-commit-push` action with an inline `git commit` / `git push` using the `release-bot[bot]` identity.

## How to test
1. Trigger the `publish` workflow via `repository_dispatch` (as done by the enterprise SDK release pipeline) with a valid `artifact_id`, `sdk_artifact_id`, and `v` payload.
2. Verify the workflow:
   - Generates the app token successfully.
   - Downloads both artifacts from `geofencing-enterprise-ios-sdk`.
   - Commits the `[AUTO] Updated <version>` change to the default branch under the `release-bot[bot]` author.
   - Pushes the tag and publishes the pod.
3. Confirm `vars.RELEASE_BOT_APP_ID` and `secrets.RELEASE_BOT_PRIVATE_KEY` are configured on the repository.

### Command line execution (This executes the workflow  only from the default branch)
```
gh api repos/Woosmap/geofencing-ios-sdk-release/dispatches \
  --method POST \
  --input - <<EOF
{
  "event_type": "pods",
  "client_payload": {
    "ref": "refs/heads/SDK4.0",
    "v": "4.5.4-alpha1",
    "artifact_id": "6548019925",
    "sdk_artifact_id": "6548019617"
  }
}
EOF
```

## Checklist:
- [x] My code follows the style guidelines for this repo
- [x] My code passes the SonarCloud check and does not add new code smells
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings/errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I don't require ops changes for this PR to go to prod
- [x] This change does not include a migration

> Ops note: requires `RELEASE_BOT_APP_ID` (repo variable) and `RELEASE_BOT_PRIVATE_KEY` (repo secret) to be set, and the `release-bot` GitHub App installed on both `geofencing-ios-sdk-release` and `geofencing-enterprise-ios-sdk`.

### Documentation
N/A

### Libs/SDKs
N/A